### PR TITLE
Fix build script path

### DIFF
--- a/gendless-web/package.json
+++ b/gendless-web/package.json
@@ -10,8 +10,8 @@
     "lint:fix": "eslint . --fix",
     "preview": "vite preview",
     "deploy": "npm run build && wrangler deploy",
-    "build:api-worker": "npm --prefix ../gendless-api-worker run build",
-    "install:api-worker": "npm uninstall gendless-api-worker && npm run build:api-worker && npm install ../gendless-api-worker --install-links"
+    "build:api-worker": "npm --prefix \"../gendless-api-worker\" run build",
+    "install:api-worker": "npm uninstall gendless-api-worker && npm run build:api-worker && npm install \"../gendless-api-worker\" --install-links"
   },
   "dependencies": {
     "gendless-api-worker": "file:../gendless-api-worker",

--- a/gendless-web/package.json
+++ b/gendless-web/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "eslint . --fix",
     "preview": "vite preview",
     "deploy": "npm run build && wrangler deploy",
-    "build:api-worker": "cd ../gendless-api-worker && npm run build",
+    "build:api-worker": "npm --prefix ../gendless-api-worker run build",
     "install:api-worker": "npm uninstall gendless-api-worker && npm run build:api-worker && npm install ../gendless-api-worker --install-links"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- prevent install script from changing directories

## Testing
- `npm run build:api-worker`
- `npm run install:api-worker`


------
https://chatgpt.com/codex/tasks/task_e_684d141c62408323801d81e22caf0602